### PR TITLE
CU-85zrp49zd_update-the-keep-alive-router-method-verbose-from-POST-to-GET_leonardo-salas

### DIFF
--- a/fastify-boilerplate.postman_collection.json
+++ b/fastify-boilerplate.postman_collection.json
@@ -119,8 +119,11 @@
 						},
 						{
 							"name": "auth keep alive",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
 							"request": {
-								"method": "POST",
+								"method": "GET",
 								"header": [
 									{
 										"key": "Content-Type",
@@ -130,7 +133,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\"keep-alive\": 1}"
+									"raw": ""
 								},
 								"url": {
 									"raw": "{{SERVER-API}}/auth/keep-alive",

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -21,7 +21,7 @@ export default function (app, opts, next) {
     handler: authController.updatePassword
   });
 
-  app.post('/keep-alive', {
+  app.get('/keep-alive', {
     handler: authController.keepAlive
   });
 


### PR DESCRIPTION
keep-alive route now works with GET